### PR TITLE
Update focus function name to be more specific

### DIFF
--- a/plugins/autofocus/fields/autofocus/assets/js/autofocus.js
+++ b/plugins/autofocus/fields/autofocus/assets/js/autofocus.js
@@ -80,7 +80,7 @@ var returnPos = function(file, filename, uri) {
 
         _ctx.drawImage(_img, 0, 0);
 
-        var _p = focus(_canvas, { debug: false }),
+        var _p = focusCanvas(_canvas, { debug: false }),
             _propX = _p.x / _w,
             _propY = _p.y / _h,
             _propX = (Math.round(_propX * 100)/100).toFixed(2),

--- a/plugins/autofocus/fields/autofocus/assets/js/vendors/focus.js
+++ b/plugins/autofocus/fields/autofocus/assets/js/vendors/focus.js
@@ -1,4 +1,4 @@
-var focus = function(canvas, options){
+var focusCanvas = function(canvas, options){
   options = options || {};
   var debug = options.debug;
 


### PR DESCRIPTION
The problem with a function name like "focus" is that is pretty general and might cause trouble with other scripts. So I made it more specific.

In my case, it collides with a focus function inside of the SimpleMDE editor plugin for Kirby.